### PR TITLE
Passing mysql_user to test_config creation.

### DIFF
--- a/manifests/developer_environment.pp
+++ b/manifests/developer_environment.pp
@@ -1,6 +1,7 @@
 class omegaup::developer_environment (
 	$root = '/opt/omegaup',
 	$user = 'vagrant',
+	$mysql_user = 'omegaup',
 ) {
 	include omegaup::java
 


### PR DESCRIPTION
File test_config.php was getting created with empty user name after `vagrant up` bootstrap causing phpunit tests to not run. 
