### PR TITLE
Add a redirect to https://omegaup.org/donate

### DIFF
--- a/manifests/org_web.pp
+++ b/manifests/org_web.pp
@@ -23,6 +23,9 @@ class omegaup::org_web (
     php            => false,
     ssl            => $ssl,
     web_root       => $org_webroot,
+    rewrite_rules  => [
+      '^/donate(/.*)?$ /#donate permanent',
+    ],
   }
 }
 

--- a/manifests/web_host.pp
+++ b/manifests/web_host.pp
@@ -2,6 +2,7 @@ define omegaup::web_host(
   $hostname = 'localhost',
   $default_server = true,
   $include_files = [],
+  $rewrite_rules = [],
   $try_files = undef,
   $ssl = false,
   $php = true,
@@ -63,6 +64,7 @@ define omegaup::web_host(
         ssl_trusted_certificate => "/etc/letsencrypt/live/${hostname}/fullchain.pem",
       },
       try_files            => $try_files,
+      rewrite_rules        => $rewrite_rules,
       require              => [File['/etc/nginx/conf.d/default.conf'],
                                Exec["${hostname}.dhparam"]],
     }
@@ -82,6 +84,7 @@ define omegaup::web_host(
         root => $web_root,
         gzip => 'on'
       },
+      rewrite_rules        => $rewrite_rules,
       try_files            => $try_files,
       require              => File['/etc/nginx/conf.d/default.conf'],
       gzip_types           => $gzip_types,


### PR DESCRIPTION
This change adds a way to add redirects for any web_host, and adds one
in org_web that rewrites /donate -> /#donate.